### PR TITLE
fixed the bug for readability of notification while hovering over it …

### DIFF
--- a/DevElevate/src/components/Layout/NotificationPanel.tsx
+++ b/DevElevate/src/components/Layout/NotificationPanel.tsx
@@ -289,7 +289,7 @@ const NotificationPanel: React.FC<NotificationPanelProps> = ({ isOpen, onClose }
               {filteredNotifications.map(notification => (
                 <div
                   key={notification.id}
-                  className={`p-4 border-l-4 ${getPriorityColor(notification.priority)} ${
+                  className={`p-4 border-l-4 group ${getPriorityColor(notification.priority)} ${
                     !notification.read ? 'bg-blue-50 dark:bg-blue-900/10' : ''
                   } hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors`}
                 >
@@ -309,12 +309,12 @@ const NotificationPanel: React.FC<NotificationPanelProps> = ({ isOpen, onClose }
                       <div className="flex items-start justify-between">
                         <div className="flex-1">
                           <h3 className={`text-sm font-medium ${
-                            state.darkMode ? 'text-white' : 'text-gray-900'
+                            state.darkMode ? 'text-white' : 'text-gray-900 group-hover:text-white'
                           }`}>
                             {notification.title}
                           </h3>
                           <p className={`text-sm mt-1 ${
-                            state.darkMode ? 'text-gray-400' : 'text-gray-600'
+                            state.darkMode ? 'text-gray-400' : 'text-gray-600 group-hover:text-gray-100'
                           }`}>
                             {notification.message}
                           </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Dev-Elevate",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION

---
name: 🛠️ Pull Request
about: Submit a pull request for code, documentation, or feature enhancement
title: '[PR] <type>: <short description>'
labels: 'pull-request', 'under review'
assignees: ''

---

# 🛠️ Pull Request Details

## 📌 Description
This pull request fixes the bug of notification text-readability while hovering in light-mode. 

<!-- A detailed description of what this PR does and why it's needed. -->
According to the issue #9, when you hover over the notification in light mode, the contents weren't readable because even though the background was changing colour, the text wasn't. 

> This PR adds the course upload module to the admin panel, allowing instructors to upload video content and attach downloadable PDFs.

---

## 🧪 Related Issues

Fixes #9  (if applicable)

---

## 🔍 Type of Change

Please delete options that are not relevant:
- [x] 🐛 Bug fix
---

## ✅ Checklist

Before submitting your PR, check all the points below:

- [✅  ] My code follows the **style guidelines** of this project
- [✅  ] I have performed a **self-review** of my code
- [ ] I have **commented** my code, especially in hard-to-understand areas
- [ ] I have made corresponding changes to the **documentation**
- [✅  ] My changes **generate no new warnings**
- [ ] I have added **tests** that prove my fix is effective or that my feature works
- [ ✅ ] New and existing unit tests pass locally
- [ ✅ ] I have **linked the related issue**


---

## 📸 Screenshots (if applicable)

Paste screenshots or a screen recording of the feature/bug fix.

Previously: 

<img width="464" height="633" alt="Screenshot 2025-07-22 132601" src="https://github.com/user-attachments/assets/06e998ef-c495-4a36-93c3-2803ba9d385b" />

After: 

<img width="1276" height="623" alt="Screenshot 2025-07-22 140649" src="https://github.com/user-attachments/assets/f50b76cb-dbfd-44c7-953c-c5970900016b" />

<img width="485" height="645" alt="Screenshot 2025-07-22 134114" src="https://github.com/user-attachments/assets/4d467ccb-245e-4f31-8c84-846f3a274106" />

---

## 🙋‍♂️ Reviewer Notes

Mention anything that reviewers should focus on or be aware of.

---

> ✅ PRs that follow the structure and guidelines are reviewed and merged faster!
