### PR TITLE
Fix broken contributors link in footer

### DIFF
--- a/DevElevate/src/components/Layout/Footer.tsx
+++ b/DevElevate/src/components/Layout/Footer.tsx
@@ -217,7 +217,7 @@ const Footer: React.FC = () => {
               
               {contributors.length > 0 && (
                 <a
-                  href="https://github.com/abhisek2004/Dev-Elevate.git/graphs/contributors"
+                  href="https://github.com/abhisek2004/Dev-Elevate/graphs/contributors"
                   target="_blank"
                   rel="noopener noreferrer"
                   className={`w-12 h-12 rounded-full border-2 border-dashed border-gray-400 flex items-center justify-center hover:border-blue-500 transition-colors ${


### PR DESCRIPTION
---
name: 🛠️ Pull Request
about: Submit a pull request for code, documentation, or feature enhancement
title: '[PR] Fix broken github contributors link in footer'
labels: 'pull-request', 'under review'
assignees: ''

---

# 🛠️ Pull Request Details

## 📌 Description

Currently the link to github contributors in the footer is broken , it directs to `https://github.com/abhisek2004/Dev-Elevate.git/graphs/contributors` , that gives a 404 error . I've replaced it with `https://github.com/abhisek2004/Dev-Elevate/graphs/contributors` that is the correct URL.
This is used when the user clicks on the `+` icon infront of the contributors in footer.
---

## 🔍 Type of Change

Please delete options that are not relevant:

- [x] 🐛 Bug fix


---

## ✅ Checklist

Before submitting your PR, check all the points below:

- [x] My code follows the **style guidelines** of this project
- [x] I have performed a **self-review** of my code
- [x] I have **commented** my code, especially in hard-to-understand areas
- [x] I have made corresponding changes to the **documentation**
- [x] My changes **generate no new warnings**
- [x] I have added **tests** that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally
- [x] I have **linked the related issue**

