### PR TITLE
Added reusable toast notifications for LearningHub module

### DIFF
--- a/DevElevate/Client/src/components/Layout/Toast.tsx
+++ b/DevElevate/Client/src/components/Layout/Toast.tsx
@@ -17,7 +17,7 @@ export default function Toast({ message, onClose, darkMode = false }: ToastProps
   }, [onClose])
 
   return (
-    <div className={`fixed top-5 right-5 min-w-[320px] flex items-center gap-3 px-4 py-3 rounded-lg shadow-lg border z-50 transition-all${darkMode? "bg-gray-800 text-yellow-400 border-gray-700": "bg-white text-yellow-600 border-gray-200"}`}>
+    <div className={`fixed top-5 right-5 min-w-[320px] flex items-center gap-3 px-4 py-3 rounded-lg shadow-lg border z-50 transition-all ${darkMode? "bg-gray-800 text-yellow-400 border-gray-700": "bg-white text-yellow-600 border-gray-200"}`}>
         <div className={`flex-shrink-0 rounded p-1 ${ darkMode? "bg-yellow-500/20": "bg-yellow-500"}`}>
           <AlertCircle className={`w-4 h-4 ${darkMode ? "text-yellow-400" : "text-white"}`} />
         </div>

--- a/DevElevate/Client/src/components/Layout/Toast.tsx
+++ b/DevElevate/Client/src/components/Layout/Toast.tsx
@@ -1,27 +1,32 @@
 import { useEffect } from "react"
 import { AlertCircle, X } from "lucide-react"
 
-//Reusable Toast component for displaying messages
-function Toast({ message, onClose }: { message: string; onClose: () => void }) {
+interface ToastProps {
+  message: string
+  onClose: () => void
+  darkMode?: boolean
+}
+
+//Reusable Toast component with Dark/Light mode support
+export default function Toast({ message, onClose, darkMode = false }: ToastProps) {
   useEffect(() => {
     const timer = setTimeout(() => {
       onClose()
-    }, 3000) 
+    }, 3000)
     return () => clearTimeout(timer)
   }, [onClose])
 
   return (
-    <div className="fixed top-5 right-5 bg-white border border-gray-200 px-4 py-3 rounded-lg shadow-lg z-50 flex items-center gap-3 min-w-[320px]">
-      <div className="flex-shrink-0 bg-yellow-500 rounded p-1">
-        <AlertCircle className="w-4 h-4 text-white" />
-      </div>
-      <div className="flex-1 text-sm font-medium text-yellow-600">{message}</div>
-      <button onClick={onClose} className="flex-shrink-0 text-yellow-600 hover:text-yellow-700 transition-colors">
-        <X className="w-4 h-4" />
-      </button>
+    <div className={`fixed top-5 right-5 min-w-[320px] flex items-center gap-3 px-4 py-3 rounded-lg shadow-lg border z-50 transition-all${darkMode? "bg-gray-800 text-yellow-400 border-gray-700": "bg-white text-yellow-600 border-gray-200"}`}>
+        <div className={`flex-shrink-0 rounded p-1 ${ darkMode? "bg-yellow-500/20": "bg-yellow-500"}`}>
+          <AlertCircle className={`w-4 h-4 ${darkMode ? "text-yellow-400" : "text-white"}`} />
+        </div>
+        <div className={`flex-1 text-sm font-medium ${darkMode ? "text-yellow-400" : "text-yellow-600"}`}>
+            {message}
+        </div>
+        <button onClick={onClose} className={`flex-shrink-0 transition-colors ${darkMode ? "text-yellow-400 hover:text-yellow-300": "text-yellow-600 hover:text-yellow-700"}`}>
+            <X className="w-4 h-4" />
+        </button>
     </div>
   )
 }
-
-export default Toast
-

--- a/DevElevate/Client/src/components/Layout/Toast.tsx
+++ b/DevElevate/Client/src/components/Layout/Toast.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react"
+import { AlertCircle, X } from "lucide-react"
+
+//Reusable Toast component for displaying messages
+function Toast({ message, onClose }: { message: string; onClose: () => void }) {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onClose()
+    }, 3000) 
+    return () => clearTimeout(timer)
+  }, [onClose])
+
+  return (
+    <div className="fixed top-5 right-5 bg-white border border-gray-200 px-4 py-3 rounded-lg shadow-lg z-50 flex items-center gap-3 min-w-[320px]">
+      <div className="flex-shrink-0 bg-yellow-500 rounded p-1">
+        <AlertCircle className="w-4 h-4 text-white" />
+      </div>
+      <div className="flex-1 text-sm font-medium text-yellow-600">{message}</div>
+      <button onClick={onClose} className="flex-shrink-0 text-yellow-600 hover:text-yellow-700 transition-colors">
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  )
+}
+
+export default Toast
+

--- a/DevElevate/Client/src/components/LearningHub/LearningHub.tsx
+++ b/DevElevate/Client/src/components/LearningHub/LearningHub.tsx
@@ -88,7 +88,7 @@ const LearningHub: React.FC = () => {
     <div className={`min-h-screen ${state.darkMode ? 'bg-gray-900' : 'bg-gray-50'} transition-colors duration-200`}>
         {/* Displays toast notification */}
         {toastMessage && (
-            <Toast message={toastMessage} onClose={() => setToastMessage("")} />
+            <Toast message={toastMessage} onClose={() => setToastMessage("")} darkMode={state.darkMode} />
         )}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="mb-8">

--- a/DevElevate/Client/src/components/LearningHub/LearningHub.tsx
+++ b/DevElevate/Client/src/components/LearningHub/LearningHub.tsx
@@ -1,10 +1,26 @@
 import React, { useState } from 'react';
 import { useGlobalState } from '../../contexts/GlobalContext';
 import { BookOpen, Code, Database, Brain, PlayCircle, FileText, CheckCircle } from 'lucide-react';
+import Toast from '../Layout/Toast';
 
 const LearningHub: React.FC = () => {
   const { state, dispatch } = useGlobalState();
   const [selectedTrack, setSelectedTrack] = useState('dsa');
+  const [toastMessage, setToastMessage] = useState("");
+
+  const alertHandler = (module: { id: string; title: string; topics: string[]; completed: boolean }, type?: string) => {
+    let message = "";
+    if(type === "Notes"){
+        message = `Notes for ${module.title} will be available soon!`;
+    }
+    else if(module.completed){
+        message = `Review for ${module.title} will be available soon!`;
+    }
+    else{
+        message = `${module.title} module will be available soon!`;
+    }
+    setToastMessage(message);
+  };
 
   const learningTracks = {
     dsa: {
@@ -70,6 +86,10 @@ const LearningHub: React.FC = () => {
 
   return (
     <div className={`min-h-screen ${state.darkMode ? 'bg-gray-900' : 'bg-gray-50'} transition-colors duration-200`}>
+        {/* Displays toast notification */}
+        {toastMessage && (
+            <Toast message={toastMessage} onClose={() => setToastMessage("")} />
+        )}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="mb-8">
           <h1 className={`text-3xl font-bold ${state.darkMode ? 'text-white' : 'text-gray-900'} mb-2`}>
@@ -199,7 +219,7 @@ const LearningHub: React.FC = () => {
                         }`}
                       >
                         <PlayCircle className="w-4 h-4" />
-                        <span>{module.completed ? 'Review' : 'Start Learning'}</span>
+                        <span onClick={() => alertHandler(module)}>{module.completed ? 'Review' : 'Start Learning'}</span>
                       </button>
                       <button className={`flex items-center space-x-2 px-4 py-2 rounded-lg border font-medium transition-colors ${
                         state.darkMode
@@ -207,7 +227,7 @@ const LearningHub: React.FC = () => {
                           : 'border-gray-300 text-gray-700 hover:bg-gray-50'
                       }`}>
                         <FileText className="w-4 h-4" />
-                        <span>Notes</span>
+                        <span onClick={() => alertHandler(module, "Notes")}>Notes</span>
                       </button>
                     </div>
                   </div>


### PR DESCRIPTION
# 🛠️ Pull Request Details

## 📌 Description
- When users click on `Review`, `Notes`, or `Start Learning` buttons (for modules that are unavailable), a **toast notification** now appears with a proper feedback message.  
- This improves UX by clearly informing the user that the module is coming soon instead of leaving them confused with unresponsive buttons.  

---

## 🧪 Related Issues
Fixes #39

---

### 🔄 Changes Made  

- Created a **`Toast` component** with Tailwind CSS & `lucide-react` icons.  
- Added auto-dismiss after `3s` with a close button.  
- Integrated `Toast` into `LearningHub.tsx`, displaying context-aware messages like:  
  - *“Review for Trees module will be available soon!”*  
  - *“Notes for Arrays module will be available soon!”*  
  - *“Linked List module will be available soon!”*  
- Ensured proper styling for both light and dark mode.

---


## 🔍 Type of Change

Please delete options that are not relevant:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactor
- [ ] 🔧 Configuration

---

## ✅ Checklist

Before submitting your PR, check all the points below:

- [x] My code follows the **style guidelines** of this project
- [x] I have performed a **self-review** of my code
- [x] I have **commented** my code, especially in hard-to-understand areas
- [ ] I have made corresponding changes to the **documentation**
- [x] My changes **generate no new warnings**
- [ ] I have added **tests** that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [x] I have **linked the related issue**

---

## 📸 Screen Recording

https://github.com/user-attachments/assets/fe872a32-0c11-464b-bb66-8a0ad9d0496e


