### PR TITLE
✅ [FEATURE] Implement Day Streak System #159 backend

### DIFF
--- a/DevElevate/Server/controller/userController.js
+++ b/DevElevate/Server/controller/userController.js
@@ -1,7 +1,10 @@
+import VisitingWebsite from "../model/visitingWebsite.js";
 import User from "../model/userModel.js";
+import Feedback from "../model/Feedback.js";
 import jwt from "jsonwebtoken";
 import bcrypt from "bcryptjs";
 import dotenv from "dotenv";
+import moment from "moment";
 dotenv.config();
 export const registerUser = async (req, res) => {
   try {
@@ -24,8 +27,6 @@ export const registerUser = async (req, res) => {
     });
 
     await newUser.save();
-  
-    
 
     res.status(201).json({ message: "User registered successfully", newUser });
   } catch (error) {
@@ -48,35 +49,151 @@ export const loginUser = async (req, res) => {
     const JWT_SECRET = process.env.JWT_SECRET;
     const JWT_EXPIRES = "3d";
     // Create JWT token
-    const token = jwt.sign(
-      { id: user._id, userId: user._id, email: user.email, role: user.role },
-      JWT_SECRET,
-      { expiresIn: JWT_EXPIRES }
-    );
+    const payLode = {
+      userId: user._id,
+    };
+    const token = jwt.sign(payLode, JWT_SECRET, { expiresIn: JWT_EXPIRES });
 
     // Set token in cookie
     res
       .cookie("token", token, {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production", // true in production
-        sameSite: process.env.NODE_ENV === "production"?"Strict":"Lax", // CSRF protection
+        sameSite: process.env.NODE_ENV === "production" ? "Strict" : "Lax", // CSRF protection
         maxAge: 3 * 24 * 60 * 60 * 1000, // 3 days in ms
       })
       .status(200)
-      .json({ 
-        message: "Login successful", 
-        userId: user._id, 
+      .json({
+        message: "Login successful",
+        userId: user._id,
         token: token,
         user: {
           id: user._id,
           name: user.name,
           email: user.email,
-          role: user.role
-        }
+          role: user.role,
+        },
       });
   } catch (error) {
     res
       .status(500)
       .json({ message: "Something went wrong", error: error.message });
+  }
+};
+
+export const logout = async (req, res) => {
+  try {
+    const token = req.cookies.token;
+
+    if (!token) {
+      return res.status(401).json({ message: "User already logout" });
+    }
+
+    res.clearCookie("token", {
+      httpOnly: true,
+      secure: true,
+      sameSite: "None",
+    });
+
+    return res.status(200).json({
+      message: "Logout successful",
+    });
+  } catch (error) {
+    return res.status(500).json({
+      message: "Something went wrong",
+      error: error.message,
+    });
+  }
+};
+
+export const currentStreak = async (req, res) => {
+  try {
+    const { userId } = req.user;
+    const user = await User.findById(userId).populate("dayStreak");
+
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
+    const today = moment().startOf("day");
+    const alreadyVisited = user.dayStreak.some((visit) =>
+      moment(visit.dateOfVisiting).isSame(today, "day")
+    );
+
+    if (!alreadyVisited) {
+      const visit = await VisitingWebsite.create({
+        user: userId,
+        dateOfVisiting: Date.now(),
+        visit: true,
+      });
+
+      user.dayStreak.push(visit._id);
+    }
+
+    await user.populate("dayStreak");
+
+    // Sort all visits by date
+    const sortedVisits = user.dayStreak
+      .map((v) => moment(v.dateOfVisiting).startOf("day"))
+      .sort((a, b) => a - b);
+
+    let currentStreak = 1;
+    let maxStreak = 1;
+    let startDate = sortedVisits[0];
+    let tempStartDate = sortedVisits[0];
+    let endDate = sortedVisits[0];
+
+    for (let i = 1; i < sortedVisits.length; i++) {
+      const diff = sortedVisits[i].diff(sortedVisits[i - 1], "days");
+      if (diff === 1) {
+        currentStreak++;
+        if (currentStreak > maxStreak) {
+          maxStreak = currentStreak;
+          startDate = tempStartDate;
+          endDate = sortedVisits[i];
+        }
+      } else if (diff > 1) {
+        currentStreak = 1;
+        tempStartDate = sortedVisits[i]; // reset tempStart
+      }
+    }
+
+    user.currentStreak = currentStreak;
+    user.longestStreak = Math.max(user.longestStreak, maxStreak);
+    user.streakStartDate = startDate;
+    user.streakEndDate = endDate;
+    await user.save();
+
+    return res.status(200).json({
+      message: `✅ Welcome back, ${user.name}`,
+      currentStreakData: {
+        currentStreak: user.currentStreak,
+        longestStreak: user.longestStreak,
+        totalDays: user.dayStreak.length,
+        streakStartDate: user.streakStartDate,
+        streakEndDate: user.streakEndDate,
+        dayStreak: user.dayStreak,
+      },
+    });
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
+};
+
+export const feedback = async (req, res) => {
+  try {
+    const { message } = req.body;
+    const { userId } = req.user;
+
+    const newFeedback = await Feedback.create({
+      message: message,
+      userId: userId,
+    });
+
+    return res.status(200).json({
+      newFeedback,
+    });
+  } catch (error) {
+    console.log(error.message);
   }
 };

--- a/DevElevate/Server/index.js
+++ b/DevElevate/Server/index.js
@@ -37,15 +37,15 @@ app.use(cors({
 app.set('trust proxy', true);
 
 // Routes
-app.use("/api/v1/auth", userRoutes);
+app.use("/api/v1", userRoutes);
+
+
 app.use("/api/admin", adminRoutes);
 app.use("/api/admin/courses", courseRoutes);
 app.use('/admin', adminFeedbackRoutes);
 
-// Basic route
-app.get('/', (req, res) => {
-  res.send('Hello from DevElevate !');
-});
+
+app.use("/",userRoutes)
 
 
 // Sample Usage of authenticate and authorize middleware for roleBased Features

--- a/DevElevate/Server/middleware/authorize.js
+++ b/DevElevate/Server/middleware/authorize.js
@@ -8,8 +8,7 @@ const authorize = (...roles) => {
         return res
           .status(401)
           .json({ message: "Unauthorized: No user info found" });
-      }
-      // Check if the user's role is included in the allowed roles
+      }      // Check if the user's role is included in the allowed roles
       if (!roles.includes(req.user.role)) {
         return res.status(403).json({ message: "Forbidden" });
       }

--- a/DevElevate/Server/middleware/errorHandler.js
+++ b/DevElevate/Server/middleware/errorHandler.js
@@ -1,1 +1,0 @@
-// ❗ errorHandler.js - Global error handler

--- a/DevElevate/Server/model/VisitingWebsite.js
+++ b/DevElevate/Server/model/VisitingWebsite.js
@@ -1,0 +1,20 @@
+import mongoose from 'mongoose';
+
+const visitingWebsiteSchema = new mongoose.Schema({
+  dateOfVisiting: {
+    type: Date,
+    required: true,
+    default: Date.now
+  },
+  visit: {
+    type: Boolean,
+    default: true
+  },
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',  
+    required: true
+  }
+});
+
+export default mongoose.model('VisitingWebsite', visitingWebsiteSchema);

--- a/DevElevate/Server/model/userModel.js
+++ b/DevElevate/Server/model/userModel.js
@@ -5,7 +5,7 @@ const userSchema = new mongoose.Schema(
   {
     name: {
       type: String,
-      required:true,
+      required: true,
       trim: true,
     },
     email: {
@@ -21,6 +21,27 @@ const userSchema = new mongoose.Schema(
     password: {
       type: String,
       required: true,
+    },
+
+    dayStreak: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "VisitingWebsite",
+      },
+    ],
+    currentStreak: {
+      type: Number,
+      default: 0,
+    },
+    longestStreak: {
+      type: Number,
+      default: 0,
+    },
+    streakStartDate: {
+      type: Date,
+    },
+    streakEndDate: {
+      type: Date,
     },
   },
   {

--- a/DevElevate/Server/package-lock.json
+++ b/DevElevate/Server/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^17.2.0",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
+        "moment": "^2.30.1",
         "mongoose": "^8.16.4",
         "nodemon": "^3.1.10",
         "zod": "^4.0.10"
@@ -885,6 +886,15 @@
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }

--- a/DevElevate/Server/package.json
+++ b/DevElevate/Server/package.json
@@ -20,6 +20,7 @@
     "dotenv": "^17.2.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
+    "moment": "^2.30.1",
     "mongoose": "^8.16.4",
     "nodemon": "^3.1.10",
     "zod": "^4.0.10"

--- a/DevElevate/Server/routes/userRoutes.js
+++ b/DevElevate/Server/routes/userRoutes.js
@@ -1,11 +1,26 @@
 import express from "express";
 const router = express.Router();
 
-import { registerUser, loginUser } from "../controller/userController.js";
-import { loginValidator, signUpValidator } from "../middleware/Validators.js";
+import {
+  registerUser,
+  loginUser,
+  currentStreak,
+  logout,
+  feedback,
+} from "../controller/userController.js";
+import { authenticateToken } from "../middleware/authMiddleware.js";
 
-router.post("/signup", registerUser);
+router.post("/auth/signup", registerUser);
+router.post("/auth/login", loginUser);
+router.get("/logout", authenticateToken, logout);
 
-router.post("/login", loginUser);
+
+
+router.post("/feedback", authenticateToken, feedback);
+
+
+
+
+router.get("/", authenticateToken, currentStreak);
 
 export default router;


### PR DESCRIPTION
✅ [FEATURE] Implement Day Streak System

Description:
Add a system to track a user's daily activity streak — how many consecutive days they've completed an activity (like solving a problem, logging in, etc.).

📌 Tasks:

Create a dayStreak field in the user schema (MongoDB)

Add logic to update streak only if user is active on a new day

Reset streak if a day is missed

Send response with current streak status in API

(Optional) Store past streak history
📅 Example:
User logs in on July 28 → streak: 1
Logs in again on July 29 → streak: 2
Skips July 30 → streak resets to 0 on July 31
💡 Notes:
Use Date comparison logic to avoid resetting on same-day logins
Optionally store lastActiveDate to compare
Could be shown on dashboard: 🔥 Current Streak: 5 Days