### PR TITLE
feat:ContentUploadManager component and related admin content routes (ISSUE 68)

### DIFF
--- a/DevElevate/Client/package-lock.json
+++ b/DevElevate/Client/package-lock.json
@@ -8,9 +8,9 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
-        "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.3",
-        "@radix-ui/react-tabs": "^1.1.12",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@reduxjs/toolkit": "^2.8.2",
         "@stripe/react-stripe-js": "^3.8.0",
         "@stripe/stripe-js": "^7.6.1",
@@ -1758,14 +1758,16 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/primitive": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
-      "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
       "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-context": "1.1.2",
@@ -1816,19 +1818,20 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz",
-      "integrity": "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.10",
-        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
         "@radix-ui/react-focus-scope": "1.1.7",
         "@radix-ui/react-id": "1.1.1",
         "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-presence": "1.1.5",
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-slot": "1.2.3",
         "@radix-ui/react-use-controllable-state": "1.2.2",
@@ -1854,6 +1857,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
       "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1865,11 +1869,12 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.10.tgz",
-      "integrity": "sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
@@ -1891,9 +1896,10 @@
       }
     },
     "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.2.tgz",
-      "integrity": "sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1969,9 +1975,10 @@
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
-      "integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-use-layout-effect": "1.1.1"
@@ -2014,11 +2021,12 @@
       }
     },
     "node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.10.tgz",
-      "integrity": "sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-collection": "1.1.7",
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-context": "1.1.2",
@@ -2047,6 +2055,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
       },
@@ -2061,17 +2070,18 @@
       }
     },
     "node_modules/@radix-ui/react-tabs": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.12.tgz",
-      "integrity": "sha512-GTVAlRVrQrSw3cEARM0nAx73ixrWDPNZAruETn3oHCNP6SbZ/hNxdxp+u7VkIEv3/sFoLq1PfcHrl7Pnp0CDpw==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-context": "1.1.2",
         "@radix-ui/react-direction": "1.1.1",
         "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-presence": "1.1.5",
         "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.10",
+        "@radix-ui/react-roving-focus": "1.1.11",
         "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
@@ -2142,6 +2152,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
       "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
       },
@@ -3355,6 +3366,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
       "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "clsx": "^2.1.1"
       },
@@ -8020,6 +8032,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
       "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"

--- a/DevElevate/Client/package.json
+++ b/DevElevate/Client/package.json
@@ -10,9 +10,9 @@
     "lint": "eslint . --ext .ts,.tsx"
   },
   "dependencies": {
-    "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.3",
-    "@radix-ui/react-tabs": "^1.1.12",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@reduxjs/toolkit": "^2.8.2",
     "@stripe/react-stripe-js": "^3.8.0",
     "@stripe/stripe-js": "^7.6.1",

--- a/DevElevate/Client/src/App.tsx
+++ b/DevElevate/Client/src/App.tsx
@@ -23,6 +23,7 @@ import CreatorPage from "./components/Legal/CreatorPage";
 import Disclaimer from "./components/Legal/Disclaimer";
 import AdminDashboard from "./components/Admin/AdminDashboard";
 import AdminSystemLogs from "./components/Admin/AdminSystemLogs";
+import ContentUploadManager from "./pages/Admin/ContentUploadManager";
 import ProtectedRoute from "./components/Auth/ProtectedRoute";
 import LoginRegister from "./components/Auth/LoginRegister";
 import Dashboard from "./components/Dashboard/Dashboard";
@@ -128,6 +129,14 @@ function App() {
                     </ProtectedRoute>
                   }
                 />
+                  <Route
+                    path="/admin/content-upload"
+                    element={
+                      <ProtectedRoute requireAdmin={true}>
+                        <ContentUploadManager />
+                      </ProtectedRoute>
+                    }
+                  />
                 <Route
                   path="/admin/logs"
                   element={

--- a/DevElevate/Client/src/components/Admin/AdminDashboard.tsx
+++ b/DevElevate/Client/src/components/Admin/AdminDashboard.tsx
@@ -80,6 +80,25 @@ const AdminDashboard: React.FC = () => {
   const [showAddNews, setShowAddNews] = useState(false);
   const [showQuizForm, setShowQuizForm] = useState(false);
   const [editingQuiz, setEditingQuiz] = useState<Quiz | null>(null);
+  interface Quiz {
+    id: string;
+    title: string;
+    topic?: string;
+    difficulty?: 'Easy' | 'Medium' | 'Hard';
+    level?: string;
+    type: 'MCQ' | 'Code';
+    description?: string;
+    questions: any[];
+    createdAt: string;
+    [key: string]: any;
+  }
+
+// Move QuizFormProps type to top-level scope
+
+  type SubmissionTrackerProps = {
+    quizzes: Quiz[];
+    darkMode: boolean;
+  };
   const [quizzes, setQuizzes] = useState<Quiz[]>([]);
   const [showAddUser, setShowAddUser] = useState(false);
 
@@ -106,6 +125,7 @@ const AdminDashboard: React.FC = () => {
       streak: number;
       level: string;
     };
+    longestStreak?: number;
   };
 
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
@@ -149,13 +169,8 @@ const AdminDashboard: React.FC = () => {
     addUserByAdmin(userData); 
   };
 
-  interface DeleteUserData {
-    userId: string;
-  }
-
-  const handleDeleteUser = (userId: DeleteUserData) => {
-    
-    deleteUserByAdmin(userId)
+  const handleDeleteUser = (userId: string) => {
+    deleteUserByAdmin(userId);
     console.log("pass-1");
   };
 
@@ -185,9 +200,13 @@ const AdminDashboard: React.FC = () => {
       setEditingQuiz(null);
     } else {
       const newQuiz: Quiz = {
-        ...data,
         id: Date.now().toString(),
         createdAt: new Date().toISOString(),
+        title: data.title,
+        description: data.description,
+        questions: data.questions,
+        type: data.type, // <-- Add this line to include the required 'type' property
+        ...data,
       };
       const newList = [...quizzes, newQuiz];
       setQuizzes(newList);
@@ -226,6 +245,8 @@ const AdminDashboard: React.FC = () => {
             setShowQuizForm(false);
             setEditingQuiz(null);
           }}
+          darkMode={globalState.darkMode}
+          token={authState.token}
         />
       ) : (
         <>
@@ -386,35 +407,7 @@ const AdminDashboard: React.FC = () => {
   ];
 
   // Filter logic
-  const filteredUsers=authState.users.filter(
-      (user) =>
-        user.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        user.email.toLowerCase().includes(searchTerm.toLowerCase())
-    )
-    .filter((user) => {
-      // Role filter
-      if (filter.role && user.role !== filter.role) return false;
-      // Date filter
-      if (
-        filter.dateFrom &&
-        new Date(user.joinDate) < new Date(filter.dateFrom)
-      )
-        return false;
-      if (filter.dateTo && new Date(user.joinDate) > new Date(filter.dateTo))
-        return false;
-      // Progress filter
-      if (
-        filter.minProgress &&
-        user.progress.totalPoints < Number(filter.minProgress)
-      )
-        return false;
-      if (
-        filter.maxProgress &&
-        user.progress.totalPoints > Number(filter.maxProgress)
-      )
-        return false;
-      return true;
-    });
+  // Removed unused filteredUsers variable
 
   const addCourse = (
     courseData: Omit<
@@ -1217,7 +1210,7 @@ const AdminDashboard: React.FC = () => {
                       <div>
                         Current:{" "}
                         <span className="font-medium">
-                          {user.currentStreak ?? 0}
+                          {user.progress?.streak ?? 0}
                         </span>
                       </div>
                       <div>

--- a/DevElevate/Client/src/components/Quiz/QuizList.tsx
+++ b/DevElevate/Client/src/components/Quiz/QuizList.tsx
@@ -15,12 +15,13 @@ export interface Quiz {
 }
 
 type QuizListProps = {
+  quizzes: Quiz[];
   darkMode: boolean;
   onEdit: (quiz: Quiz) => void;
+  onDelete: (id: string) => void;
 };
 
-const QuizList: React.FC<QuizListProps> = ({ darkMode, onEdit }) => {
-  const [quizzes, setQuizzes] = useState<Quiz[]>([]);
+const QuizList: React.FC<QuizListProps> = ({ quizzes, darkMode, onEdit, onDelete }) => {
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
   const fetchQuizzes = async () => {

--- a/DevElevate/Client/src/components/Quiz/SubmissionTracker.tsx
+++ b/DevElevate/Client/src/components/Quiz/SubmissionTracker.tsx
@@ -26,11 +26,20 @@ interface QuizSubmissions {
   submissions: Submission[];
 }
 
+interface Quiz {
+  quiz: string;
+  quizId: string;
+  topic?: string;
+  message?: string;
+  submissions: Submission[];
+}
+
 interface SubmissionTrackerProps {
+  quizzes: Quiz[];
   darkMode: boolean;
 }
 
-const SubmissionTracker: React.FC<SubmissionTrackerProps> = ({ darkMode }) => {
+const SubmissionTracker: React.FC<SubmissionTrackerProps> = ({ quizzes, darkMode }) => {
   const [data, setData] = useState<QuizSubmissions[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -42,8 +51,8 @@ const SubmissionTracker: React.FC<SubmissionTrackerProps> = ({ darkMode }) => {
       setLoading(true);
       setError(null);
       try {
-        const res = await instance.get('/api/v1/admin/quiz/submission')
-        setData(res.data);
+        const res = await instance.get('/api/v1/admin/quiz/submission');
+        setData(res.data as QuizSubmissions[]);
       } catch (err: any) {
         setError(err.response?.data?.message || 'Failed to fetch submissions');
       } finally {

--- a/DevElevate/Client/src/contexts/AuthContext.tsx
+++ b/DevElevate/Client/src/contexts/AuthContext.tsx
@@ -197,7 +197,31 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
         console.error("Error parsing saved auth state:", error);
       }
     }
+    // Hydrate from backend using cookie
+    hydrateUserFromBackend();
   }, []);
+
+  // Fetch user from backend using cookie
+  const hydrateUserFromBackend = async () => {
+    try {
+      const response = await fetch(`${baseUrl}/api/v1/auth/me`, {
+        method: "GET",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+      const data = await response.json();
+      if (response.ok && data.user) {
+        dispatch({
+          type: "LOGIN_SUCCESS",
+          payload: { user: data.user, token: data.token || null },
+        });
+      }
+    } catch (error) {
+      // Ignore if not logged in
+    }
+  };
 
   // Save auth state to localStorage
   useEffect(() => {

--- a/DevElevate/Client/src/pages/Admin/ContentUploadManager.tsx
+++ b/DevElevate/Client/src/pages/Admin/ContentUploadManager.tsx
@@ -1,0 +1,173 @@
+import React, { useState, useEffect, useRef } from "react";
+
+type Content = {
+  _id: string;
+  title: string;
+  link: string;
+  type: string;
+};
+import axiosInstance from "../../api/axiosinstance";
+
+const ContentUploadManager: React.FC = () => {
+  const [contents, setContents] = useState<Content[]>([]);
+  const [form, setForm] = useState({ title: "", link: "", type: "pdf" });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [dragActive, setDragActive] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const fetchContents = async () => {
+    setLoading(true);
+    try {
+  const res = await axiosInstance.get("/api/v1/admin/content/content");
+      setContents(res.data as Content[]);
+    } catch (err) {
+      setError("Failed to fetch contents");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchContents();
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  // Drag and drop handlers
+  const handleDrag = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.type === "dragenter" || e.type === "dragover") {
+      setDragActive(true);
+    } else if (e.type === "dragleave") {
+      setDragActive(false);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragActive(false);
+    // Only accept text/links, not files
+    const text = e.dataTransfer.getData("text/plain");
+    if (text) {
+      setForm((prev) => ({ ...prev, link: text }));
+    }
+  };
+
+  const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    setForm({ ...form, link: e.clipboardData.getData("text") });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.title || !form.link || !form.type) return setError("All fields required");
+    setLoading(true);
+    setError("");
+    try {
+  await axiosInstance.post("/api/v1/admin/content/content/upload", form);
+      setForm({ title: "", link: "", type: "pdf" });
+      fetchContents();
+    } catch (err) {
+      setError("Upload failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setLoading(true);
+    try {
+  await axiosInstance.delete(`/api/v1/admin/content/content/${id}`);
+      fetchContents();
+    } catch (err) {
+      setError("Delete failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <h2 className="text-2xl font-bold mb-4">Admin Content Upload Manager</h2>
+      <form onSubmit={handleSubmit} className="mb-6 flex flex-col gap-3">
+        <div
+          className={`border-2 border-dashed rounded p-4 text-center ${dragActive ? "border-blue-600 bg-blue-50" : "border-gray-300"}`}
+          onDragEnter={handleDrag}
+          onDragOver={handleDrag}
+          onDragLeave={handleDrag}
+          onDrop={handleDrop}
+        >
+          <input
+            name="title"
+            value={form.title}
+            onChange={handleChange}
+            placeholder="Title"
+            className="border p-2 rounded w-full mb-2"
+          />
+          <input
+            ref={inputRef}
+            name="link"
+            value={form.link}
+            onChange={handleChange}
+            onPaste={handlePaste}
+            placeholder="Paste or drag online link (PDF, YouTube, GitHub, etc.)"
+            className="border p-2 rounded w-full mb-2"
+          />
+          <select name="type" value={form.type} onChange={handleChange} className="border p-2 rounded w-full mb-2">
+            <option value="pdf">PDF</option>
+            <option value="ebook">Ebook</option>
+            <option value="note">Note</option>
+            <option value="youtube">YouTube</option>
+            <option value="github">GitHub</option>
+          </select>
+          <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded w-full" disabled={loading}>
+            {loading ? "Uploading..." : "Upload"}
+          </button>
+          <div className="text-sm text-gray-500 mt-2">Drag a link or paste it above. No file uploads supported.</div>
+          {error && <div className="text-red-500 mt-2">{error}</div>}
+        </div>
+      </form>
+      <h3 className="text-xl font-semibold mb-2">Uploaded Contents</h3>
+      <div className="overflow-x-auto">
+        <table className="w-full border">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="p-2 border">Title</th>
+              <th className="p-2 border">Type</th>
+              <th className="p-2 border">Link</th>
+              <th className="p-2 border">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {contents.map((c) => (
+              <tr key={c._id}>
+                <td className="p-2 border">{c.title}</td>
+                <td className="p-2 border">{c.type}</td>
+                <td className="p-2 border">
+                  <a href={c.link} target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">
+                    View
+                  </a>
+                </td>
+                <td className="p-2 border">
+                  <button
+                    onClick={() => handleDelete(c._id)}
+                    className="bg-red-500 text-white px-2 py-1 rounded"
+                    disabled={loading}
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default ContentUploadManager;

--- a/DevElevate/Server/controller/adminContentController.js
+++ b/DevElevate/Server/controller/adminContentController.js
@@ -1,0 +1,30 @@
+import Content from "../models/Content.js";
+
+export async function uploadContent(req, res) {
+  const { title, link, type } = req.body;
+  if (!title || !link || !type) return res.status(400).json({ error: "All fields required" });
+  try {
+    const content = await Content.create({ title, link, type, uploadedBy: req.adminId });
+    res.status(201).json(content);
+  } catch (err) {
+    res.status(500).json({ error: "Upload failed" });
+  }
+}
+
+export async function deleteContent(req, res) {
+  try {
+    await Content.findByIdAndDelete(req.params.id);
+    res.status(200).json({ message: "Deleted" });
+  } catch (err) {
+    res.status(500).json({ error: "Delete failed" });
+  }
+}
+
+export async function getAllContent(req, res) {
+  try {
+    const contents = await Content.find().sort({ createdAt: -1 });
+    res.status(200).json(contents);
+  } catch (err) {
+    res.status(500).json({ error: "Fetch failed" });
+  }
+}

--- a/DevElevate/Server/controller/userController.js
+++ b/DevElevate/Server/controller/userController.js
@@ -1,3 +1,21 @@
+// Get current authenticated user
+export const getCurrentUser = async (req, res) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ message: "Not authenticated" });
+    }
+    // Return user info (no password)
+    const user = {
+      id: req.user._id,
+      name: req.user.name,
+      email: req.user.email,
+      role: req.user.role,
+    };
+    return res.status(200).json({ user });
+  } catch (error) {
+    return res.status(500).json({ message: "Error fetching user", error: error.message });
+  }
+};
 import VisitingWebsite from "../model/VisitingWebsite.js";
 import User from "../model/UserModel.js";
 import Feedback from "../model/Feedback.js";
@@ -73,10 +91,11 @@ export const loginUser = async (req, res) => {
     const JWT_SECRET = process.env.JWT_SECRET;
     const JWT_EXPIRES = "3d";
     // Create JWT token
-    const payLode = {
-      userId: user._id,
-    };
-    const token = jwt.sign(payLode, JWT_SECRET, { expiresIn: JWT_EXPIRES });
+      const payLode = {
+        userId: user._id,
+        role: user.role,
+      };
+      const token = jwt.sign(payLode, JWT_SECRET, { expiresIn: JWT_EXPIRES });
 
     // Set token in cookie
     res.cookie("token", token, {

--- a/DevElevate/Server/index.js
+++ b/DevElevate/Server/index.js
@@ -14,6 +14,7 @@ import quizRoutes from './routes/quizRoutes.js'
 import atsRoutes from './routes/atsRoutes.js';
 import notificationRoutes from "./routes/notificationRoutes.js";
 import aiRoutes from "./routes/aiRoutes.js"
+import adminContentRoutes from './routes/adminContentRoutes.js';
 
 // Connect to MongoDB only if MONGO_URI is available
 if (process.env.MONGO_URI) {
@@ -59,7 +60,7 @@ app.use("/api/v1/admin/courses", courseRoutes); // course create/delete/edit
 app.use("/api/v1/admin/feedback", adminFeedbackRoutes); // feedback-related
 app.use("/api/v1/admin/quiz", quizRoutes); //quiz-related
 app.use("/api/v1", aiRoutes);
-
+app.use("/api/v1/admin/content", adminContentRoutes);
 
 // Sample Usage of authenticate and authorize middleware for roleBased Features
 app.get(

--- a/DevElevate/Server/models/Content.js
+++ b/DevElevate/Server/models/Content.js
@@ -1,0 +1,12 @@
+import mongoose from "mongoose";
+
+const ContentSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  link: { type: String, required: true },
+  type: { type: String, enum: ["pdf", "ebook", "note", "youtube", "github"], required: true },
+  uploadedBy: { type: mongoose.Schema.Types.ObjectId, ref: "Admin" },
+  createdAt: { type: Date, default: Date.now },
+});
+
+const Content = mongoose.model("Content", ContentSchema);
+export default Content;

--- a/DevElevate/Server/routes/adminContentRoutes.js
+++ b/DevElevate/Server/routes/adminContentRoutes.js
@@ -1,0 +1,15 @@
+import express from "express";
+import { uploadContent, deleteContent, getAllContent } from "../controller/adminContentController.js";
+import { authenticateToken, requireAdmin } from "../middleware/authMiddleware.js";
+
+const router = express.Router();
+// POST /admin/content/upload
+router.post("/content/upload", authenticateToken, requireAdmin, uploadContent);
+
+// DELETE /admin/content/:id
+router.delete("/content/:id", authenticateToken, requireAdmin, deleteContent);
+
+// GET /admin/content
+router.get("/content", authenticateToken, requireAdmin, getAllContent);
+
+export default router;

--- a/DevElevate/Server/routes/userRoutes.js
+++ b/DevElevate/Server/routes/userRoutes.js
@@ -9,7 +9,10 @@ import {
   feedback,
   googleUser,
   latestNews,
+  getCurrentUser,
 } from "../controller/userController.js";
+// Get current authenticated user
+router.get("/auth/me", authenticateToken, getCurrentUser);
 import { authenticateToken } from "../middleware/authMiddleware.js";
 
 router.post("/auth/signup", registerUser);


### PR DESCRIPTION
Admin Content Upload Manager (Frontend + Backend):

Admins can add online resources (PDF, YouTube, GitHub, etc.) via a drag-and-drop or paste link UI.
Responsive table displays all uploaded content with delete options.
Input fields for Title, Link, and Type (PDF, YouTube, GitHub, etc.).
Backend routes for uploading, deleting, and listing content, with metadata saved to MongoDB.
All admin content routes are protected (only accessible by authenticated admins).
UI uses Tailwind and is ready for Shadcn UI components.