### PR TITLE
feat(auth): Disable paste on registration password fields

### DIFF
--- a/DevElevate/Client/src/components/Auth/LoginRegister.tsx
+++ b/DevElevate/Client/src/components/Auth/LoginRegister.tsx
@@ -334,6 +334,7 @@ const LoginRegister: React.FC = () => {
                     name="password"
                     value={formData.password}
                     onChange={handleInputChange}
+                    onPaste={(e) => e.preventDefault()}
                     className="py-3 pr-12 pl-10 w-full text-gray-900 bg-white rounded-lg border border-gray-300 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:bg-gray-700 dark:text-white"
                     placeholder="Enter your password"
                     required
@@ -385,6 +386,7 @@ const LoginRegister: React.FC = () => {
                         name="confirmPassword"
                         value={formData.confirmPassword}
                         onChange={handleInputChange}
+                        onPaste={(e) => e.preventDefault()}
                         className="py-3 pr-4 pl-10 w-full text-gray-900 bg-white rounded-lg border border-gray-300 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:bg-gray-700 dark:text-white"
                         placeholder="Confirm your password"
                         required={!isLogin}


### PR DESCRIPTION
## Description
feat: Disable paste on password fields

This change enhances the security of the registration form by disabling paste functionality in the 'password' and 'confirm password' input fields.

Previously, users could copy the password from the first field and paste it into the second, which defeats the purpose of the confirm password field for catching typos. This change forces manual re-entry, improving user security and data integrity.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
