### PR TITLE
fix(dashboard): reset learning progress and counters for new users

### DIFF
--- a/DevElevate/Client/src/components/Dashboard/Dashboard.tsx
+++ b/DevElevate/Client/src/components/Dashboard/Dashboard.tsx
@@ -1,82 +1,105 @@
-import React, { useEffect } from 'react';
-import { useAuth } from '../../contexts/AuthContext';
-import { useGlobalState } from '../../contexts/GlobalContext'; 
-import StatsCards from './StatsCards';
-import ProgressWidget from './ProgressWidget';
-import NewsWidget from './NewsWidget';
-import QuickActions from './QuickActions';
-import StreakCalendar from './StreakCalendar';
-import DailyGoals from './DailyGoals';
-import QuizHistory from '../Quiz/QuizHistory';
-import { User } from '../../contexts/GlobalContext';
-import { baseUrl } from '../../config/routes';
+import React, { useEffect } from "react";
+import { useAuth } from "../../contexts/AuthContext";
+import { useGlobalState, User } from "../../contexts/GlobalContext";
+import StatsCards from "./StatsCards";
+import ProgressWidget from "./ProgressWidget";
+import NewsWidget from "./NewsWidget";
+import QuickActions from "./QuickActions";
+import StreakCalendar from "./StreakCalendar";
+import DailyGoals from "./DailyGoals";
+import QuizHistory from "../Quiz/QuizHistory";
+import { baseUrl } from "../../config/routes";
 
 const Dashboard: React.FC = () => {
   const { state: authState } = useAuth();
   const { state, dispatch } = useGlobalState();
-useEffect(() => {
-  // Initialize user if not exists
-  if (!state.user) {
-    const defaultUser: User = {
-      id: '1',
-      name: 'John Doe',
-      email: 'john@example.com',
-      joinDate: new Date().toISOString(),
-      streak: 0,
-      totalPoints: 1250,
-      level: 'Intermediate'
-    };
-    dispatch({ type: 'SET_USER', payload: defaultUser });
-  }
 
-  // Fetch streak data from backend
-  const fetchStreakData = async () => {
-    try {
-      const response = await fetch(`${baseUrl}/api/v1/user/streak`, {
-        headers: {
-          'Authorization': `Bearer ${authState.sessionToken}`
-        }
-      });
-      const data = await response.json();
-
-      if (response.ok) {
-        // Update global state with streak data
-        dispatch({ 
-          type: 'SET_USER', 
-          payload: {
-            ...state.user,
-            streak: data.currentStreakData.currentStreak
-          }
-        });
-
-        // Convert streak data for StreakCalendar
-        const streakData: Record<string, boolean> = {};
-        data.currentStreakData.dayStreak.forEach((visit: { dateOfVisiting: string | number | Date }) => {
-          const date = new Date(visit.dateOfVisiting).toISOString().split('T')[0];
-          streakData[date] = true;
-        });
-
-        dispatch({ type: 'HYDRATE_STATE', payload: { streakData } });
-      }
-    } catch (error) {
-      console.error('Error fetching streak data:', error);
+  useEffect(() => {
+    // Initialize user if not exists
+    if (!state.user) {
+      const defaultUser: User = {
+        id: "1",
+        name: "John Doe",
+        email: "john@example.com",
+        joinDate: new Date().toISOString(),
+        streak: 0,
+        totalPoints: 0,
+        level: "Intermediate",
+      };
+      dispatch({ type: "SET_USER", payload: defaultUser });
     }
-  };
 
-  if (authState.isAuthenticated && authState.sessionToken) {
-    fetchStreakData();
-  }
-}, [authState.isAuthenticated, authState.sessionToken, dispatch]);
+    // Fetch streak data from backend
+    const fetchStreakData = async () => {
+      try {
+        const response = await fetch(`${baseUrl}/api/v1/user/streak`, {
+          headers: {
+            Authorization: `Bearer ${authState.sessionToken}`,
+          },
+        });
+        const data = await response.json();
+
+        if (response.ok) {
+          // ✅ Build a complete safe User object
+          const safeUser: User = {
+            id: state.user?.id ?? authState.user?.id ?? "temp-id",
+            name: state.user?.name ?? authState.user?.name ?? "New User",
+            email: state.user?.email ?? authState.user?.email ?? "unknown@example.com",
+            joinDate: state.user?.joinDate ?? new Date().toISOString(),
+            streak: data.currentStreakData?.currentStreak ?? 0,
+            totalPoints: state.user?.totalPoints ?? 0,
+            level: state.user?.level ?? "Beginner",
+          };
+
+          dispatch({
+            type: "SET_USER",
+            payload: safeUser,
+          });
+
+          // Convert streak data for StreakCalendar
+          const streakData: Record<string, boolean> = {};
+          data.currentStreakData?.dayStreak?.forEach(
+            (visit: { dateOfVisiting: string | number | Date }) => {
+              const date = new Date(visit.dateOfVisiting)
+                .toISOString()
+                .split("T")[0];
+              streakData[date] = true;
+            }
+          );
+
+          dispatch({ type: "HYDRATE_STATE", payload: { streakData } });
+        }
+      } catch (error) {
+        console.error("Error fetching streak data:", error);
+      }
+    };
+
+    if (authState.isAuthenticated && authState.sessionToken) {
+      fetchStreakData();
+    }
+  }, [authState.isAuthenticated, authState.sessionToken, dispatch, state.user]);
 
   return (
-    <div className={`min-h-screen transition-colors duration-300 ${state.darkMode ? 'bg-gray-900' : 'bg-gray-50'} transition-colors duration-200`}>
+    <div
+      className={`min-h-screen transition-colors duration-300 ${
+        state.darkMode ? "bg-gray-900" : "bg-gray-50"
+      } transition-colors duration-200`}
+    >
       <div className="px-4 py-10 mx-auto max-w-7xl sm:px-6 lg:px-8">
         {/* Welcome Section */}
         <div className="mb-10">
-          <h1 className={`text-4xl font-extrabold tracking-tight mb-3 ${state.darkMode ? 'text-white' : 'text-gray-900'}`}>
-            Welcome back, {authState.user?.name || 'Developer'}! 👋
+          <h1
+            className={`text-4xl font-extrabold tracking-tight mb-3 ${
+              state.darkMode ? "text-white" : "text-gray-900"
+            }`}
+          >
+            Welcome back, {authState.user?.name || "Developer"}! 👋
           </h1>
-          <p className={`text-lg sm:text-xl font-medium leading-relaxed ${state.darkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+          <p
+            className={`text-lg sm:text-xl font-medium leading-relaxed ${
+              state.darkMode ? "text-gray-300" : "text-gray-600"
+            }`}
+          >
             Ready to continue your learning journey?
           </p>
         </div>

--- a/DevElevate/Client/src/components/Dashboard/ProgressWidget.tsx
+++ b/DevElevate/Client/src/components/Dashboard/ProgressWidget.tsx
@@ -1,99 +1,74 @@
-import React from 'react';
-import { BookOpen, Code, Brain, Database, ArrowRight } from 'lucide-react';
-import { useGlobalState } from '../../contexts/GlobalContext';
-import { useNavigate } from 'react-router-dom';
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { useGlobalState } from "../../contexts/GlobalContext";
+
 const ProgressWidget: React.FC = () => {
   const { state } = useGlobalState();
-  const navigate= useNavigate()
+  const navigate = useNavigate();
 
-  const learningTracks = [
-    {
-      id: 'dsa',
-      title: 'Data Structures & Algorithms',
-      icon: Code,
-      progress: 65,
-      color: 'from-blue-500 to-cyan-500',
-      modules: 12,
-      completed: 8
-    },
-    {
-      id: 'java',
-      title: 'Java Programming',
-      icon: BookOpen,
-      progress: 78,
-      color: 'from-orange-500 to-red-500',
-      modules: 10,
-      completed: 8
-    },
-    {
-      id: 'mern',
-      title: 'MERN Stack',
-      icon: Database,
-      progress: 45,
-      color: 'from-green-500 to-teal-500',
-      modules: 15,
-      completed: 7
-    },
-    {
-      id: 'aiml',
-      title: 'AI/ML & Data Science',
-      icon: Brain,
-      progress: 32,
-      color: 'from-purple-500 to-pink-500',
-      modules: 18,
-      completed: 6
-    }
-  ];
-  const handleViewAllClick = () => {
-    navigate("/learning")
+  // ✅ Check if the user has any learning progress
+  const hasProgress =
+    state.learningProgress &&
+    Object.keys(state.learningProgress).length > 0 &&
+    Object.values(state.learningProgress).some(
+      (topic) =>
+        topic.completed > 0 ||
+        topic.total > 0 ||
+        Object.keys(topic.modules || {}).length > 0
+    );
+
+  if (!hasProgress) {
+    // ✅ Empty state UI for new users
+    return (
+      <div className="p-6 bg-white dark:bg-gray-800 rounded-xl shadow-md">
+        <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">
+          Learning Progress
+        </h2>
+        <p className="text-gray-500 dark:text-gray-400">
+          You haven't started learning yet.{" "}
+          <span
+            className="text-blue-500 font-medium hover:underline cursor-pointer"
+            onClick={() => navigate("/learning")} // ✅ Use navigate instead of full reload
+          >
+            Explore the Learning Hub
+          </span>{" "}
+          and start your first course!
+        </p>
+      </div>
+    );
   }
 
+  // ✅ Show progress bars if user has progress
   return (
-    <div className={`${state.darkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'} rounded-xl p-6 border shadow-sm`}>
-      <div className="flex items-center justify-between mb-6">
-        <h3 className={`text-xl font-semibold ${state.darkMode ? 'text-white' : 'text-gray-900'}`}>
-          Learning Progress
-        </h3>
-<button
-  className="flex items-center gap-1 text-sm font-medium text-blue-500 transition-colors duration-150 hover:text-blue-600"
-  onClick={handleViewAllClick}
->
-  <span>View All</span>
-  <ArrowRight className='w-4 h-4'/>
-</button>
-      </div>
+    <div className="p-6 bg-white dark:bg-gray-800 rounded-xl shadow-md">
+      <h2 className="text-lg font-semibold mb-4 text-gray-800 dark:text-gray-100">
+        Learning Progress
+      </h2>
 
-      <div className="space-y-4">
-        {learningTracks.map((track) => {
-          const Icon = track.icon;
-          return (
-            <div key={track.id} className="flex items-center space-x-4">
-              <div className={`p-3 rounded-lg bg-gradient-to-r ${track.color}`}>
-                <Icon className="w-5 h-5 text-white" />
-              </div>
-              <div className="flex-1">
-                <div className="flex items-center justify-between mb-1">
-                  <h4 className={`font-medium ${state.darkMode ? 'text-white' : 'text-gray-900'}`}>
-                    {track.title}
-                  </h4>
-                  <span className={`text-sm ${state.darkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                    {track.completed}/{track.modules} modules
-                  </span>
-                </div>
-                <div className="w-full h-2 bg-gray-200 rounded-full dark:bg-gray-700">
-                  <div
-                    className={`h-2 rounded-full bg-gradient-to-r ${track.color}`}
-                    style={{ width: `${track.progress}%` }}
-                  ></div>
-                </div>
-                <p className={`text-sm mt-1 ${state.darkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                  {track.progress}% Complete
-                </p>
-              </div>
-            </div>
-          );
-        })}
-      </div>
+      {Object.entries(state.learningProgress).map(([topic, progress]) => (
+        <div key={topic} className="mb-4">
+          <div className="flex justify-between text-sm font-medium text-gray-700 dark:text-gray-300">
+            <span>{topic}</span>
+            <span>
+              {progress.completed}/{progress.total} modules
+            </span>
+          </div>
+
+          {/* Progress Bar */}
+          <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2 mt-1">
+            <div
+              className="bg-blue-500 h-2 rounded-full transition-all duration-300"
+              style={{
+                width: `${
+                  progress.total > 0
+                    ? Math.min((progress.completed / progress.total) * 100, 100)
+                    : 0
+                }%`,
+              }}
+            ></div>
+          </div>
+        </div>
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
## 🐛 Bug Description
When a new user signs up and logs in with a fresh email, the dashboard shows pre-filled progress (modules completed and streak data). This is inconsistent with a beginner profile.

## 📍 Steps to Reproduce
1. Go to the signup page.
2. Register using a brand-new email address.
3. Log in.
4. Observe that progress bars and counters are already partially filled.

## ✅ Expected Behavior
- A new user should have **0% progress** on all modules.
- Dashboard counters (streak, goals, points) should be fully reset.
- Learning progress section should show "empty state" until the user starts learning.

## 🔧 Fix Implemented
- Reset `learningProgress`, `streak`, and `totalPoints` in `GlobalContext` when a new user is created.
- Fixed `ProgressWidget` to show the proper "Explore Learning Hub" message when no progress exists.
- Ensured data persists properly in `localStorage`.

## 🖼️ Screenshots
| Before | After |
|-------|-------|
| <img width="1919" height="1064" alt="Screenshot 2025-09-29 234704" src="https://github.com/user-attachments/assets/98c07c0c-0021-4fab-88ac-619ea2834e9c" /> | <img width="1915" height="1049" alt="Screenshot 2025-09-30 010455" src="https://github.com/user-attachments/assets/d832e1c4-cef0-4862-af03-4665a2e6c4de" /> |

---


