### PR TITLE
Forgot Password Page Added

### DIFF
--- a/DevElevate/Client/src/App.tsx
+++ b/DevElevate/Client/src/App.tsx
@@ -63,7 +63,7 @@ import FallBackNotes from "./pages/Notes/FallBackNotes.jsx"
 import ReactPattern from "./pages/Notes/ReactPatterns/ReactPattern.jsx"
 import Roadmap from "./pages/RoadmapPage/Roadmap"
 import UserVideoPage from "./pages/videoPages/VideoPage.js";
-
+import ForgotPass from "./components/Auth/ForgotPass";
 
 
 // ✅ AppContent
@@ -88,6 +88,15 @@ const AppContent = () => {
           element={
             <ProtectedRoute requireAuth={false}>
               <LoginRegister />
+            </ProtectedRoute>
+          }
+        />
+        
+        <Route
+          path="/forgot-password"
+          element={
+            <ProtectedRoute requireAuth={false}>
+            <ForgotPass />
             </ProtectedRoute>
           }
         />

--- a/DevElevate/Client/src/components/Auth/ForgotPass.tsx
+++ b/DevElevate/Client/src/components/Auth/ForgotPass.tsx
@@ -1,0 +1,141 @@
+import React, { useState, ChangeEvent, FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+import { motion } from "framer-motion";
+import {
+  Eye,
+  EyeOff,
+  Mail,
+  Lock,
+  ChevronLeft,
+} from "lucide-react";
+
+interface FormData {
+  email: string;
+  newPassword: string;
+  confirmPassword: string;
+}
+
+const ForgotPass: React.FC = () => {
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState<FormData>({
+    email: "",
+    newPassword: "",
+    confirmPassword: "",
+  });
+
+  const [showNewPassword, setShowNewPassword] = useState<boolean>(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState<boolean>(false);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const { newPassword, confirmPassword } = formData;
+
+    if (newPassword.length < 6) {
+      alert("Password must be at least 6 characters!");
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      alert("Password Doesn't Match");
+      return;
+    }
+
+    alert("Password reset successful! Redirecting to login...");
+    navigate("/");
+  };
+
+  return (
+    <div className="flex justify-center items-center min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900">
+      <motion.div
+        initial={{ opacity: 0, y: -50 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+        className="bg-gray-800 p-8 rounded-2xl shadow-lg w-full max-w-md"
+      >
+        {/* Back to Login */}
+        <div
+          className="flex items-center mb-6 cursor-pointer"
+          onClick={() => navigate("/")}
+        >
+          <ChevronLeft className="text-white" />
+          <span className="text-white text-sm ml-1">Back to Login</span>
+        </div>
+
+        {/* Title */}
+        <h2 className="text-2xl font-bold text-white text-center mb-6">
+          Reset Password
+        </h2>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Email */}
+          <div className="relative">
+            <Mail className="absolute left-3 top-3 text-gray-400" />
+            <input
+              type="email"
+              name="email"
+              placeholder="Enter your email"
+              value={formData.email}
+              onChange={handleChange}
+              className="w-full pl-10 pr-4 py-2 rounded-lg bg-gray-700 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              required
+            />
+          </div>
+
+          {/* New Password */}
+          <div className="relative">
+            <Lock className="absolute left-3 top-3 text-gray-400" />
+            <input
+              type={showNewPassword ? "text" : "password"}
+              name="newPassword"
+              placeholder="New Password"
+              value={formData.newPassword}
+              onChange={handleChange}
+              className="w-full pl-10 pr-10 py-2 rounded-lg bg-gray-700 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              required
+            />
+            <div
+              className="absolute right-3 top-3 cursor-pointer text-gray-400"
+              onClick={() => setShowNewPassword(!showNewPassword)}
+            >
+              {showNewPassword ? <EyeOff /> : <Eye />}
+            </div>
+          </div>
+
+          {/* Confirm Password */}
+          <div className="relative">
+            <Lock className="absolute left-3 top-3 text-gray-400" />
+            <input
+              type={showConfirmPassword ? "text" : "password"}
+              name="confirmPassword"
+              placeholder="Confirm Password"
+              value={formData.confirmPassword}
+              onChange={handleChange}
+              className="w-full pl-10 pr-10 py-2 rounded-lg bg-gray-700 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              required
+            />
+            <div
+              className="absolute right-3 top-3 cursor-pointer text-gray-400"
+              onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+            >
+              {showConfirmPassword ? <EyeOff /> : <Eye />}
+            </div>
+          </div>
+
+          {/* Submit */}
+          <button
+            type="submit"
+            className="w-full py-2 bg-gradient-to-r from-indigo-500 to-purple-500 rounded-lg text-white font-semibold hover:opacity-90 transition"
+          >
+            Submit
+          </button>
+        </form>
+      </motion.div>
+    </div>
+  );
+};
+
+export default ForgotPass;

--- a/DevElevate/Client/src/components/Auth/LoginRegister.tsx
+++ b/DevElevate/Client/src/components/Auth/LoginRegister.tsx
@@ -336,6 +336,13 @@ const LoginRegister: React.FC = () => {
                 )}
               </div>
             )}
+            
+            <p
+              className="text-sm text-blue-400 cursor-pointer hover:underline mt-2"
+              onClick={() => navigate("/forgot-password")}
+            >
+              Forgot Password?
+            </p>
 
             {isLogin && (
               <div className="absolute top-0 right-1 w-full max-w-sm mx-auto h-60">


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #532 .

## Rationale for this change

Earlier, the forgot password was not available, as well the option of the "forgot password" option was not present on the login page.

## What changes are included in this PR?

1. "Forgot Password" option is added on the login page.
2. "Forgot Password" option redirects to the new route "forgot-password"
3. Added the forgot password page.
4. The page has 3 inputs :-
    a. Email
    b. New Password
    c. Confirm Password
5. A. If New Password is less than 6 characters, it will give an alert.
    B. If New password and Confirm Password doesn't match it will give an alert.
6. If New Password and Confirm Password are same it will redirect to the login page.

## Are these changes tested?

Yes, these all changes are tested on the localhost.

## Are there any user-facing changes?

Yes, now the users can access the forgot password page through the login page. 

## Screenshots(if Applicable)
<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/909e9015-6488-43e1-8cd0-3bab1f8eda89" />
