### PR TITLE
fix page scroll issue - 563

### DIFF
--- a/DevElevate/Client/src/pages/Landing/components/Footer.tsx
+++ b/DevElevate/Client/src/pages/Landing/components/Footer.tsx
@@ -175,6 +175,7 @@ const HomePage = () => {
                   <li key={link.name}>
                     <Link
                       to={link.path}
+                      onClick={scrollToTop}
                       className="text-gray-400 transition-colors duration-300 hover:text-white"
                     >
                       {link.name}


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #563 

## Rationale for this change

Previously, when clicking a link in the footer that navigates to another page, the page would load starting from the bottom instead of scrolling to the top. This created a confusing user experience, especially on long pages. This change ensures that the page scrolls to the top upon navigation.

## What changes are included in this PR?

- Added logic to scroll the page to the top when a footer link is clicked and a new page is loaded.

## Are these changes tested?

- Yes, the change was manually tested to ensure that the page scrolls to the top after clicking footer links and navigating to a new route.
- No automated test was added as this involves scroll behavior which is primarily UI/UX and may require integration/UI testing setup.

## Are there any user-facing changes?

- Yes. Users will now see the new page load from the top instead of the bottom when navigating via footer links, improving the browsing experience.

## Screenshots (if Applicable)

*Not applicable* – this is a behavioral fix with no visual UI changes.
