### PR TITLE
Implemented Persistent Cookie Consent Storage using LocalStorage

### DIFF
--- a/DevElevate/Client/src/pages/Landing/LandingPage.tsx
+++ b/DevElevate/Client/src/pages/Landing/LandingPage.tsx
@@ -54,10 +54,10 @@ function LandingPage() {
   const [showNewsletter, setShowNewsletter] = useState(false);
   const [email, setEmail] = useState("");
 
-  // Check sessionStorage on load
+  // Check localStorage on load
   useEffect(() => {
-    const accepted = sessionStorage.getItem("privacyAccepted");
-    if (accepted === "true") {
+    const consent = localStorage.getItem("cookieConsent");
+    if (consent === "accepted" || consent === "rejected") {
       setShowBanner(false);
       setShowNewsletter(false);
     } else {
@@ -68,13 +68,13 @@ function LandingPage() {
   const handleAccept = () => {
     setShowBanner(false);
     setShowNewsletter(true);
-    sessionStorage.setItem("privacyAccepted", "true");
+    localStorage.setItem("cookieConsent", "accepted");
   };
 
   const handleReject = () => {
     setShowBanner(false);
     setShowNewsletter(true);
-    sessionStorage.removeItem("privacyAccepted"); // will trigger again on refresh
+    localStorage.setItem("cookieConsent", "rejected");
   };
 
   const handleSubscribe = async (e: React.FormEvent) => {


### PR DESCRIPTION
Hello Team! & @abhisek2004 

This pull request updates the cookie consent logic on the landing page to use **`localStorage` instead of `sessionStorage`**, allowing consent decisions to persist across browser sessions. It also refines the handling of consent states to distinguish between accepted and rejected statuses.

**Cookie consent logic improvements:**

1.  Switched from using `sessionStorage` to `localStorage` for storing and checking the user's cookie consent status, ensuring persistence across sessions. (`LandingPage.tsx`)

2.  Updated the consent state handling to explicitly set `"accepted"` or `"rejected"` in `localStorage` when the user accepts or rejects the cookie banner, and adjusted the UI logic to respond to these states. (`LandingPage.tsx`)

**Objective**

The goal of this change is to improve the user experience by remembering the user's choice regarding cookie consent. Previously, the banner would reappear every time the page was refreshed, which could be intrusive for returning users.

**Implementation Details**

I have updated  `@file:LandingPage.tsx`  to include a persistence mechanism using the browser's localStorage.

1. _Storage Logic_: When a user clicks "Accept" or "Reject", their preference ('accepted' or 'rejected') is now saved to localStorage under the key cookieConsent.

2. _Initialization Check_: Added a useEffect hook that runs on component mount. It checks if a cookieConsent value already exists. If a value is found, the Cookie Banner is automatically hidden, and the Newsletter modal is suppressed (to prevent immediate popup overlap).

3. If no value is found, the banner is displayed as normal.

**Verification**

- _After Acceptance_: Clicking "Accept" hides the banner and saves the value. Reloading the page confirms the banner stays hidden.

- _After Rejection_: Clicking "Reject" functions similarly, ensuring the user's preference is respected.

Thanks for giving me the opportunity to contribute! 

<img width="803" height="700" alt="Screenshot 2025-11-26 013140" src="https://github.com/user-attachments/assets/bdf1278f-f351-4ebb-9c5a-5fb52c10c531" />
